### PR TITLE
Fix top-p parameter.

### DIFF
--- a/openai-chat.el
+++ b/openai-chat.el
@@ -70,7 +70,7 @@ STREAM, STOP, MAX-TOKENS, PRESENCE-PENALTY, FREQUENCY-PENALTY, and LOGIT-BIAS."
            `(("model"             . ,model)
              ("messages"          . ,messages)
              ("temperature"       . ,temperature)
-             ("top-p"             . ,top-p)
+             ("top_p"             . ,top-p)
              ("n"                 . ,n)
              ("stream"            . ,stream)
              ("stop"              . ,stop)


### PR DESCRIPTION
The nucleus sampling parameter is named `top_p` for the openai API, but it was passed with the name `top-p`.