### PR TITLE
add support for different api key types. default to bearer token

### DIFF
--- a/openai.el
+++ b/openai.el
@@ -69,6 +69,10 @@ The function should take no arguments and return a string containing the key.
 A function, `openai-key-auth-source', that retrieves the key from
 auth-source is provided for convenience.")
 
+(defvar openai-key-type :bearer
+  "Variable storing the openai key type.
+Should be one of either :bearer or :azure-api.")
+
 (defvar openai-user ""
   "A unique identifier representing your end-user, which can help OpenAI to
 monitor and detect abuse.")
@@ -115,10 +119,15 @@ return KEY."
 Arguments CONTENT-TYPE, KEY, and ORG-ID are common request headers."
   (setq key (openai--resolve-key key))
   (open--alist-omit-null `(("Content-Type"        . ,content-type)
-                           ("Authorization"       . ,(if (or (null key)
+                           ,(if (equal openai-key-type :bearer)
+                                `("Authorization" . ,(if (or (null key)
                                                              (string-empty-p key))
                                                          ""
                                                        (concat "Bearer " key)))
+                              `("api-key"         . ,(if (or (null key)
+                                                             (string-empty-p key))
+                                                         ""
+                                                       key)))
                            ("OpenAI-Organization" . ,org-id))))
 
 (defun openai--json-encode (object)

--- a/openai.el
+++ b/openai.el
@@ -125,15 +125,14 @@ return KEY."
 Arguments CONTENT-TYPE, KEY, and ORG-ID are common request headers."
   (setq key (openai--resolve-key key))
   (open--alist-omit-null `(("Content-Type"        . ,content-type)
-                           ,(if (equal openai-key-type :bearer)
-                                `("Authorization" . ,(if (or (null key)
-                                                             (string-empty-p key))
-                                                         ""
-                                                       (concat "Bearer " key)))
-                              `("api-key"         . ,(if (or (null key)
-                                                             (string-empty-p key))
-                                                         ""
-                                                       key)))
+                           ,(if (or (null key)
+                                     (string-empty-p key))
+                                 ""
+                              (pcase openai-key-type
+                                (:bearer    `("Authorization" . ,(concat "Bearer " key)))
+                                (:azure-api `("api-key" . ,key))
+                                (_           (user-error "Invalid key type: %s"
+                                                         openai-key-type))))
                            ("OpenAI-Organization" . ,org-id))))
 
 (defun openai--json-encode (object)

--- a/openai.el
+++ b/openai.el
@@ -69,9 +69,15 @@ The function should take no arguments and return a string containing the key.
 A function, `openai-key-auth-source', that retrieves the key from
 auth-source is provided for convenience.")
 
-(defvar openai-key-type :bearer
-  "Variable storing the openai key type.
-Should be one of either :bearer or :azure-api.")
+(defcustom openai-key-type :bearer
+  "The type of key determines how the openai-key is sent in the request.
+For Azure keys without an expiration meant to be sent in the \"api-key\" header,
+use :azure-api.
+For OpenAI or Azure AD keys meant to be sent in the \"Authorization\" header,
+use :bearer. Default is :bearer."
+  :type '(choice (const :tag "bearer" :bearer)
+                 (const :tag "azure-api" :azure-api))
+  :group 'openai)
 
 (defvar openai-user ""
   "A unique identifier representing your end-user, which can help OpenAI to


### PR DESCRIPTION
Closes #22 

Example config for azure API key (non-bearer):

```elisp
(setq openai-base-url "https://YOUR-ORG.openai.azure.com/openai/deployments/YOUR-DEPLOYMENT")
(setq openai-key #'openai-key-auth-source)
(setq openai-key-type :azure-api)
```